### PR TITLE
fix: set margin-bottom value for all major headers

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -254,26 +254,16 @@ body { margin-left: auto;
        max-width: 1400px;
        counter-reset: sidenote-counter; }
 
-h1 { font-weight: 400;
-     font-style: italic;
-     margin-top: 2.1rem;
-     margin-bottom: 0;
-     font-size: 2.2rem;
-     line-height: 1; }
+h1, h2, h3 {
+  font-weight: 400;
+  font-style: italic;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  line-height: 1;
+}
 
-h2 { font-style: italic;
-     font-weight: 400;
-     margin-top: 2.1rem;
-     margin-bottom: 0;
-     font-size: 2.2rem;
-     line-height: 1; }
-
-h3 { font-style: italic;
-     font-weight: 400;
-     font-size: 1.7rem;
-     margin-top: 2rem;
-     margin-bottom: 0;
-     line-height: 1; }
+h1, h2 { font-size: 2.2rem; }
+h3 { font-size: 1.7rem; }
 
 hr { display: block;
      height: 1px;


### PR DESCRIPTION
## Summary

Previous to this change, `margin-bottom` was set to zero for `h3`-level headers. In some cases, the header overlapped with a codeblock thereby cutting off part of the text. 

This PR explicitly sets a `margin-bottom` value for `h1`, `h2`, and `h3` headers. In addition, it groups common attributes together (like `font-weight` and `line-height`) and moves out `font-size` into their respective groups (`h1,h2` and `h3` respectively).

### Visual examples

Given this [example](https://lipanski.com/posts/dockerfile-ruby-best-practices#dockerfile-for-a-plain-ruby-app-or-a-rails-app-without-assets), here's what's in production today:

![text-overlaps-with-codeblock](https://user-images.githubusercontent.com/15894826/116258821-22d85500-a72a-11eb-96d7-99062ee2c9d9.png)

... and here's what these changes _should_ do:

![margin-bottom-ensures-no-overlap](https://user-images.githubusercontent.com/15894826/116259359-967a6200-a72a-11eb-9051-0f281fffa944.png)

---

Hello, @lipanski! I'm Francis. 👋  I came across your [Best practices when writing a Dockerfile for a Ruby application](https://lipanski.com/posts/dockerfile-ruby-best-practices) while tinkering away on a [small project](https://github.com/francisfuzz/hello-world-rb). Thanks for sharing your knowledge with the community - I certainly benefitted from reading it! 📖 ✨ 

